### PR TITLE
Add Windows 11 x64 release build support

### DIFF
--- a/BUILD_WINDOWS.md
+++ b/BUILD_WINDOWS.md
@@ -1,0 +1,170 @@
+# Building Steve AI Mod for Windows 11 x64
+
+This guide provides step-by-step instructions for creating a release build of the Steve AI Minecraft mod on Windows 11 x64.
+
+## Prerequisites
+
+### Required Software
+
+1. **Java Development Kit (JDK) 17 or later**
+   - Download from: https://adoptium.net/temurin/releases/
+   - Select: Windows x64, JDK 17 or 21 (LTS)
+   - During installation, ensure "Add to PATH" is selected
+
+2. **Git for Windows** (if cloning from repository)
+   - Download from: https://git-scm.com/download/win
+
+### Verification
+
+Open PowerShell or Command Prompt and verify Java installation:
+
+```powershell
+java -version
+```
+
+You should see output showing Java 17 or later:
+```
+openjdk version "17.0.x" or "21.0.x"
+```
+
+## Building the Mod
+
+### Option 1: Using Windows PowerShell
+
+1. **Open PowerShell** in the project directory
+
+2. **Run the build command:**
+   ```powershell
+   .\gradlew.bat build
+   ```
+
+3. **Wait for the build to complete** (first build may take 5-10 minutes as it downloads dependencies)
+
+### Option 2: Using Command Prompt (cmd)
+
+1. **Open Command Prompt** in the project directory
+
+2. **Run the build command:**
+   ```cmd
+   gradlew.bat build
+   ```
+
+3. **Wait for the build to complete**
+
+## Build Output
+
+After a successful build, you'll find the mod JAR file at:
+
+```
+build\libs\steve-ai-mod-1.0.0.jar
+```
+
+This JAR file is your **release build** ready for distribution.
+
+## Clean Build
+
+If you need to rebuild from scratch:
+
+```powershell
+.\gradlew.bat clean build
+```
+
+## Release Build Optimizations
+
+The build is already configured with release optimizations:
+- Parallel builds enabled for faster compilation
+- Gradle caching enabled
+- 3GB JVM heap for optimal build performance
+
+## Installation
+
+To use the built mod:
+
+1. Ensure you have **Minecraft 1.20.1** with **Forge 47.2.0** installed
+2. Copy `steve-ai-mod-1.0.0.jar` to your Minecraft `mods` folder:
+   ```
+   %APPDATA%\.minecraft\mods\
+   ```
+3. Configure the mod as described in the main README.md
+
+## Troubleshooting
+
+### "JAVA_HOME not set" Error
+
+Set JAVA_HOME environment variable:
+
+1. Open System Properties → Advanced → Environment Variables
+2. Add new System Variable:
+   - Variable name: `JAVA_HOME`
+   - Variable value: `C:\Program Files\Eclipse Adoptium\jdk-17.x.x-hotspot` (or your JDK path)
+3. Restart PowerShell/Command Prompt
+
+### "gradlew.bat: command not found"
+
+Ensure you're running the command from the project root directory where `gradlew.bat` is located.
+
+### Build Fails with "OutOfMemoryError"
+
+Increase JVM heap size in `gradle.properties`:
+```properties
+org.gradle.jvmargs=-Xmx4G
+```
+
+### Network/Firewall Issues
+
+If the build fails downloading dependencies:
+- Ensure your firewall allows Gradle to access:
+  - https://maven.minecraftforge.net
+  - https://repo.maven.apache.org
+- Try using a VPN or different network if corporate firewall blocks Maven repositories
+
+## Advanced: Creating a Distribution Package
+
+To create a complete distribution package:
+
+```powershell
+# Build the mod
+.\gradlew.bat build
+
+# Create distribution folder
+mkdir release
+Copy-Item "build\libs\steve-ai-mod-1.0.0.jar" -Destination "release\"
+Copy-Item "README.md" -Destination "release\"
+Copy-Item "LICENSE" -Destination "release\" -ErrorAction SilentlyContinue
+
+# Compress to ZIP
+Compress-Archive -Path "release\*" -DestinationPath "steve-ai-mod-1.0.0-windows.zip"
+```
+
+## System Requirements
+
+### For Building:
+- **OS:** Windows 11 x64 (or Windows 10 x64)
+- **RAM:** 4GB minimum, 8GB recommended
+- **Disk Space:** 2GB for Gradle cache and build artifacts
+- **Java:** JDK 17 or later
+
+### For Running the Mod:
+- **Minecraft:** 1.20.1
+- **Forge:** 47.2.0
+- **Java:** JRE/JDK 17 or later
+- **API Key:** OpenAI, Groq, or Gemini (configured in mod config)
+
+## Version Information
+
+- **Mod Version:** 1.0.0
+- **Minecraft Version:** 1.20.1
+- **Forge Version:** 47.2.0
+- **Java Version:** 17+
+- **ForgeGradle:** 6.x
+
+## Additional Resources
+
+- **Minecraft Forge:** https://files.minecraftforge.net/
+- **ForgeGradle Documentation:** https://docs.minecraftforge.net/en/fg-6.x/
+- **Main README:** See README.md in project root
+- **Issue Tracker:** https://github.com/YuvDwi/Steve/issues
+
+## License
+
+MIT License - See LICENSE file for details

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you want to understand how it works, start in the agent package. That's where
 
 ## Building From Source
 
-Standard Gradle stuff:
+### Linux/Mac:
 
 ```bash
 git clone https://github.com/YuvDwi/Steve.git
@@ -117,7 +117,21 @@ cd Steve
 ./gradlew build
 ```
 
-Output JAR is in `build/libs/`.
+### Windows 11 x64:
+
+**Quick build:**
+```powershell
+.\gradlew.bat build
+```
+
+**Automated release build:**
+```powershell
+.\build-release.ps1
+```
+
+For detailed Windows build instructions, see [BUILD_WINDOWS.md](BUILD_WINDOWS.md).
+
+Output JAR is in `build/libs/steve-ai-mod-1.0.0.jar`.
 
 ## Usage Examples
 

--- a/build-release.bat
+++ b/build-release.bat
@@ -1,0 +1,67 @@
+@echo off
+REM Release Build Script for Steve AI Mod (Windows 11 x64)
+REM This script automates the release build process
+
+echo ========================================
+echo Steve AI Mod - Release Build Script
+echo ========================================
+echo.
+
+REM Check if Java is installed
+java -version >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ERROR: Java is not installed or not in PATH
+    echo Please install Java 17 or later from: https://adoptium.net/
+    pause
+    exit /b 1
+)
+
+echo [1/4] Java version check...
+java -version
+echo.
+
+echo [2/4] Cleaning previous build...
+call gradlew.bat clean --no-daemon
+if %errorlevel% neq 0 (
+    echo ERROR: Clean failed
+    pause
+    exit /b 1
+)
+echo.
+
+echo [3/4] Building release JAR...
+call gradlew.bat build --no-daemon
+if %errorlevel% neq 0 (
+    echo ERROR: Build failed
+    echo.
+    echo Troubleshooting tips:
+    echo - Check your internet connection
+    echo - Ensure firewall allows access to Maven repositories
+    echo - Try running: gradlew.bat build --refresh-dependencies
+    pause
+    exit /b 1
+)
+echo.
+
+echo [4/4] Verifying build output...
+if exist "build\libs\steve-ai-mod-1.0.0.jar" (
+    echo SUCCESS: Release build completed!
+    echo.
+    echo Build output: build\libs\steve-ai-mod-1.0.0.jar
+    echo File size:
+    dir "build\libs\steve-ai-mod-1.0.0.jar" | find "steve-ai-mod"
+    echo.
+    echo To install: Copy the JAR to your Minecraft mods folder
+    echo Location: %%APPDATA%%\.minecraft\mods\
+) else (
+    echo ERROR: Build artifact not found
+    echo Expected: build\libs\steve-ai-mod-1.0.0.jar
+    pause
+    exit /b 1
+)
+
+echo.
+echo ========================================
+echo Build Complete!
+echo ========================================
+pause

--- a/build-release.ps1
+++ b/build-release.ps1
@@ -1,0 +1,142 @@
+# Release Build Script for Steve AI Mod (Windows 11 x64)
+# PowerShell version with enhanced features
+
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "Steve AI Mod - Release Build Script" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Function to check command success
+function Test-LastCommand {
+    param([string]$ErrorMessage)
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: $ErrorMessage" -ForegroundColor Red
+        exit 1
+    }
+}
+
+# Check Java installation
+Write-Host "[1/5] Checking Java installation..." -ForegroundColor Yellow
+try {
+    $javaVersion = java -version 2>&1 | Select-Object -First 1
+    Write-Host "✓ $javaVersion" -ForegroundColor Green
+
+    # Verify Java 17+
+    if ($javaVersion -match "version `"(\d+)") {
+        $majorVersion = [int]$matches[1]
+        if ($majorVersion -lt 17) {
+            Write-Host "ERROR: Java 17 or later required. Found: Java $majorVersion" -ForegroundColor Red
+            Write-Host "Download from: https://adoptium.net/" -ForegroundColor Yellow
+            exit 1
+        }
+    }
+} catch {
+    Write-Host "ERROR: Java is not installed or not in PATH" -ForegroundColor Red
+    Write-Host "Download from: https://adoptium.net/" -ForegroundColor Yellow
+    exit 1
+}
+Write-Host ""
+
+# Check Gradle wrapper
+Write-Host "[2/5] Checking Gradle wrapper..." -ForegroundColor Yellow
+if (-not (Test-Path "gradlew.bat")) {
+    Write-Host "ERROR: gradlew.bat not found. Ensure you're in the project root directory." -ForegroundColor Red
+    exit 1
+}
+Write-Host "✓ Gradle wrapper found" -ForegroundColor Green
+Write-Host ""
+
+# Clean previous build
+Write-Host "[3/5] Cleaning previous build artifacts..." -ForegroundColor Yellow
+& .\gradlew.bat clean --no-daemon
+Test-LastCommand "Clean failed"
+Write-Host "✓ Clean completed" -ForegroundColor Green
+Write-Host ""
+
+# Build release JAR
+Write-Host "[4/5] Building release JAR (this may take a few minutes)..." -ForegroundColor Yellow
+$buildStart = Get-Date
+& .\gradlew.bat build --no-daemon
+Test-LastCommand "Build failed. Check error messages above."
+$buildEnd = Get-Date
+$buildDuration = ($buildEnd - $buildStart).TotalSeconds
+Write-Host "✓ Build completed in $([math]::Round($buildDuration, 1)) seconds" -ForegroundColor Green
+Write-Host ""
+
+# Verify build output
+Write-Host "[5/5] Verifying build output..." -ForegroundColor Yellow
+$jarPath = "build\libs\steve-ai-mod-1.0.0.jar"
+
+if (Test-Path $jarPath) {
+    $jarFile = Get-Item $jarPath
+    $jarSizeMB = [math]::Round($jarFile.Length / 1MB, 2)
+
+    Write-Host "✓ Release build successful!" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host "BUILD OUTPUT" -ForegroundColor Cyan
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host "File:     $jarPath" -ForegroundColor White
+    Write-Host "Size:     $jarSizeMB MB" -ForegroundColor White
+    Write-Host "Created:  $($jarFile.LastWriteTime)" -ForegroundColor White
+    Write-Host ""
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host "INSTALLATION INSTRUCTIONS" -ForegroundColor Cyan
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host "1. Copy the JAR file to your Minecraft mods folder:" -ForegroundColor White
+    Write-Host "   $env:APPDATA\.minecraft\mods\" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "2. Ensure you have:" -ForegroundColor White
+    Write-Host "   - Minecraft 1.20.1" -ForegroundColor Yellow
+    Write-Host "   - Forge 47.2.0" -ForegroundColor Yellow
+    Write-Host "   - API key configured in config/steve-common.toml" -ForegroundColor Yellow
+    Write-Host ""
+
+    # Optional: Open build folder
+    $openFolder = Read-Host "Open build folder? (Y/N)"
+    if ($openFolder -eq "Y" -or $openFolder -eq "y") {
+        Start-Process "build\libs"
+    }
+
+    # Optional: Create release package
+    Write-Host ""
+    $createPackage = Read-Host "Create distribution ZIP package? (Y/N)"
+    if ($createPackage -eq "Y" -or $createPackage -eq "y") {
+        Write-Host "Creating distribution package..." -ForegroundColor Yellow
+
+        $releaseDir = "release"
+        if (Test-Path $releaseDir) {
+            Remove-Item $releaseDir -Recurse -Force
+        }
+        New-Item -ItemType Directory -Path $releaseDir | Out-Null
+
+        Copy-Item $jarPath -Destination $releaseDir
+        Copy-Item "README.md" -Destination $releaseDir
+        Copy-Item "BUILD_WINDOWS.md" -Destination $releaseDir
+        if (Test-Path "LICENSE") {
+            Copy-Item "LICENSE" -Destination $releaseDir
+        }
+
+        $zipPath = "steve-ai-mod-1.0.0-windows-x64.zip"
+        if (Test-Path $zipPath) {
+            Remove-Item $zipPath -Force
+        }
+
+        Compress-Archive -Path "$releaseDir\*" -DestinationPath $zipPath
+        Write-Host "✓ Distribution package created: $zipPath" -ForegroundColor Green
+
+        $zipFile = Get-Item $zipPath
+        $zipSizeMB = [math]::Round($zipFile.Length / 1MB, 2)
+        Write-Host "  Package size: $zipSizeMB MB" -ForegroundColor White
+    }
+
+} else {
+    Write-Host "ERROR: Build artifact not found at $jarPath" -ForegroundColor Red
+    Write-Host "The build may have failed. Check the error messages above." -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "Build process completed successfully!" -ForegroundColor Green
+Write-Host "========================================" -ForegroundColor Cyan

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,17 @@
-plugins {
-    id 'eclipse'
-    id 'idea'
-    id 'maven-publish'
-    id 'net.minecraftforge.gradle' version '[6.0,6.2)'
+buildscript {
+    repositories {
+        maven { url = 'https://maven.minecraftforge.net' }
+        mavenCentral()
+    }
+    dependencies {
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '6.+', changing: true
+    }
 }
+
+apply plugin: 'net.minecraftforge.gradle'
+apply plugin: 'eclipse'
+apply plugin: 'idea'
+apply plugin: 'maven-publish'
 
 version = '1.0.0'
 group = 'com.steve.ai'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,9 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
+# Parallel builds for faster compilation
+org.gradle.parallel=true
+
+# Gradle caching
+org.gradle.caching=true
+


### PR DESCRIPTION
- Add comprehensive BUILD_WINDOWS.md documentation
- Create automated build scripts (build-release.bat and build-release.ps1)
- Update build.gradle to use buildscript approach for better compatibility
- Optimize gradle.properties with parallel builds and caching
- Update README.md with Windows-specific build instructions
- Configure ForgeGradle 6.x for Minecraft 1.20.1

Build improvements:
- PowerShell script with progress indicators and error handling
- Batch script for legacy Windows command prompt support
- Automatic build verification and optional distribution packaging
- Detailed troubleshooting guide for common Windows build issues

The release build can now be easily created on Windows 11 x64 using:
  .\build-release.ps1 (recommended)
  .\build-release.bat (alternative)
  .\gradlew.bat build (manual)