### PR TITLE
Fix: Use KeyBinding instead of hardcoded K key in command window

### DIFF
--- a/src/main/java/com/steve/ai/client/SteveOverlayScreen.java
+++ b/src/main/java/com/steve/ai/client/SteveOverlayScreen.java
@@ -27,8 +27,10 @@ public class SteveOverlayScreen extends Screen {
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        // K key to close
-        if (keyCode == 75 && !hasShiftDown() && !hasControlDown() && !hasAltDown()) { // K
+        // Check if the pressed key matches the configured TOGGLE_GUI key binding
+        // This now respects user's key configuration instead of hardcoded K key
+        if (KeyBindings.TOGGLE_GUI != null &&
+                KeyBindings.TOGGLE_GUI.matches(keyCode, scanCode) && !hasShiftDown() && !hasControlDown() && !hasAltDown()) { // K
             SteveGUI.toggle();
             if (minecraft != null) {
                 minecraft.setScreen(null);


### PR DESCRIPTION
### Fix: user key binding in command window

When the user changes the toggle GUI key binding from K to another key (e.g., apostrophe), **the command window would still close when pressing K**. The new key binding would only work to open the window, but K would always close it.

`SteveOverlayScreen.java` was checking for hardcoded `keyCode == 75` (K key) instead of using the configured key binding.

-> Replaced hardcoded `keyCode == 75` check with `KeyBindings.TOGGLE_GUI.matches(keyCode, scanCode)`

### Tested
- Tested with default K key binding : Work
- Tested with custom key binding (apostrophe): Work
- Confirmed K key can now be typed in command window without closing it when rebound

Fixes the issue where key binding configuration was inconsistent between opening and closing the GUI.