### PR TITLE
fix: garbled text while building on windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ base {
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
 minecraft {
     mappings channel: 'official', version: '1.20.1'
 


### PR DESCRIPTION
## Fix: Explicitly set UTF-8 encoding for Java compilation

### Problem
Windows builds fail with encoding errors when source files contain Unicode characters (e.g., ↑↓, →) because Windows defaults to `windows-31j` encoding.

### Solution
Add explicit UTF-8 encoding configuration to ensure consistent compilation across all platforms.

### Changes
- Configure all `JavaCompile` tasks to use UTF-8 encoding

This ensures cross-platform compatibility and prevents encoding-related compilation errors.