### PR TITLE
feat: enable gpt-5 model

### DIFF
--- a/config/steve-common.toml.example
+++ b/config/steve-common.toml.example
@@ -4,13 +4,14 @@
     apiKey = "your-openai-api-key-here"
     
     # Using GPT-3.5-turbo (much cheaper than GPT-4 for testing)
-    model = "gpt-3.5-turbo"
+    model = "gpt-5-mini"
     
     # Maximum tokens per API request
-    maxTokens = 1000
+    maxTokens = 8000
     
-    # Temperature (0.0-2.0, lower is more deterministic)
-    temperature = 0.7
+	#Temperature for AI responses (0.0-2.0, lower is more deterministic). Note: gpt-5 and newer models only support value 1
+	#Range: 0.0 ~ 2.0
+	temperature = 1
 
 [behavior]
     # Ticks between action checks (20 ticks = 1 second)

--- a/src/main/java/com/steve/ai/ai/OpenAIClient.java
+++ b/src/main/java/com/steve/ai/ai/OpenAIClient.java
@@ -102,7 +102,8 @@ public class OpenAIClient {
         JsonObject body = new JsonObject();
         body.addProperty("model", SteveConfig.OPENAI_MODEL.get());
         body.addProperty("temperature", SteveConfig.TEMPERATURE.get());
-        body.addProperty("max_tokens", SteveConfig.MAX_TOKENS.get());
+        // gpt-5 and newer models use max_completion_tokens instead of max_tokens
+        body.addProperty("max_completion_tokens", SteveConfig.MAX_TOKENS.get());
 
         JsonArray messages = new JsonArray();
         

--- a/src/main/java/com/steve/ai/config/SteveConfig.java
+++ b/src/main/java/com/steve/ai/config/SteveConfig.java
@@ -31,16 +31,16 @@ public class SteveConfig {
             .define("apiKey", "");
         
         OPENAI_MODEL = builder
-            .comment("OpenAI model to use (gpt-4, gpt-4-turbo-preview, gpt-3.5-turbo)")
-            .define("model", "gpt-4-turbo-preview");
+            .comment("OpenAI model to use (gpt-5-mini, gpt-5, etc.)")
+            .define("model", "gpt-5-mini");
         
         MAX_TOKENS = builder
             .comment("Maximum tokens per API request")
             .defineInRange("maxTokens", 8000, 100, 65536);
         
         TEMPERATURE = builder
-            .comment("Temperature for AI responses (0.0-2.0, lower is more deterministic)")
-            .defineInRange("temperature", 0.7, 0.0, 2.0);
+            .comment("Temperature for AI responses (0.0-2.0, lower is more deterministic). Note: gpt-5 and newer models only support value 1")
+            .defineInRange("temperature", 1.0, 0.0, 2.0);
         
         builder.pop();
 


### PR DESCRIPTION
# OpenAI API: gpt-5-mini Support

## Overview

This PR adds support for gpt-5-mini and newer gpt-5 models in the OpenAI API client. The changes address API parameter specification differences in the newer models.

## Changes

### 1. API Parameter Changes
- Changed `max_tokens` → `max_completion_tokens`
  - Newer gpt-5 models require `max_completion_tokens` instead of `max_tokens`

### 2. Default Value Updates
- Default model: `gpt-4-turbo-preview` → `gpt-5-mini`
- Default temperature: `0.7` → `1.0`
  - gpt-5 and newer models only support temperature value of 1

### 3. Configuration Comments Update
- Updated model selection comments
- Added note about gpt-5+ temperature restrictions

## Modified Files

- `src/main/java/com/steve/ai/ai/OpenAIClient.java`
  - Changed to use `max_completion_tokens` parameter
- `src/main/java/com/steve/ai/config/SteveConfig.java`
  - Changed default model to `gpt-5-mini`
  - Changed default temperature to `1.0`
  - Updated comments

## Testing

- [x] Verified API requests work correctly with gpt-5-mini model
- [x] Confirmed error responses (`unsupported_parameter`, `unsupported_value`) are resolved

## Compatibility

- Older models (gpt-3.5-turbo, gpt-4, etc.) will still work, but will use `max_completion_tokens` parameter
- You can still use older models by changing the model name or temperature value in the config file

## Related Errors

The following errors are resolved:
- `Unsupported parameter: 'max_tokens' is not supported with this model`
- `Unsupported value: 'temperature' does not support 0.7 with this model`
