### PR TITLE
fix: add UTF-8 encoding for JavaCompile tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,3 +109,7 @@ publishing {
     }
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+


### PR DESCRIPTION
## Problem

Garbled characters (mojibake) occur on Windows systems when building the project, both in the Gradle console output and in-game text.

## Cause

Windows uses GBK encoding (code page 936) by default, while the project contains UTF-8 encoded source files. Without explicitly setting the encoding, Java compiler uses the system default encoding.

## Solution

Add UTF-8 encoding configuration for all JavaCompile tasks in build.gradle using configureEach for lazy configuration per Gradle best practices:

```groovy
tasks.withType(JavaCompile).configureEach {
    options.encoding = 'UTF-8'
}
```