### PR TITLE
Configure Gradle for China region: mirrors, proxy, and ForgeGradle co…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ minecraft {
 sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 repositories {
+    maven { url = 'https://lss233.littleservice.cn/repositories/minecraft/' }
+    maven { url = 'https://maven.minecraftforge.net/' }
+    maven { url 'https://maven.aliyun.com/repository/public' }
     mavenCentral()
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
-
+systemProp.http.proxyHost=127.0.0.1
+systemProp.http.proxyPort=7897
+systemProp.https.proxyHost=127.0.0.1
+systemProp.https.proxyPort=7897

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,14 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        maven { url = 'https://maven.neoforged.net/releases' }
         maven { url = 'https://maven.minecraftforge.net/' }
     }
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.5.0'
+    // id 'org.gradle.toolchains.foojay-resolver-convention' version '0.5.0'
+    // Removed: conflicts with net.minecraftforge.gradle toolchain handling
 }
 
 rootProject.name = 'steve'


### PR DESCRIPTION
…mpatibility

- Add Tencent Gradle mirror for faster downloads in China
- Configure HTTP/HTTPS proxy for corporate/network setups
- Remove foojay-resolver-convention plugin that conflicts with ForgeGradle
- Add Minecraft/Forge/AliYun repositories for dependency resolution