### PR TITLE
Fix: Steves get stuck idle after finishing their build quadrant

### DIFF
--- a/src/main/java/com/steve/ai/action/CollaborativeBuildManager.java
+++ b/src/main/java/com/steve/ai/action/CollaborativeBuildManager.java
@@ -199,10 +199,14 @@ public class CollaborativeBuildManager {
         BlockPlacement block = section.getNextBlock();
         
         if (block == null) {
+            // This Steve's section is complete - reassign them to another
+            // section that still needs work (previously this re-queried the
+            // same finished section and always returned null, leaving the
+            // Steve stuck idle instead of helping elsewhere).
+            sectionIndex = assignSteveToSection(build, steveName);
             if (sectionIndex != null) {
                 section = build.sections.get(sectionIndex);
                 block = section.getNextBlock();
-                if (block != null) {                }
             }
         }
         


### PR DESCRIPTION
## Bug
In `CollaborativeBuildManager.getNextBlock()`, once a Steve's assigned
section (quadrant) was fully built, the fallback logic re-queried the
*same* already-completed section instead of reassigning the Steve to a
different, still-incomplete section:

```java
if (block == null) {
    if (sectionIndex != null) {
        section = build.sections.get(sectionIndex);
        block = section.getNextBlock();
        if (block != null) {                }
    }
}
```

Since `sectionIndex` never changed, `section.getNextBlock()` always
returned `null` again, so the Steve had no more blocks to place and
simply went idle — even while other quadrants of the structure were
still unfinished. This is the root cause of the "dynamic rebalancing"
described in the README not actually working: `assignSteveToSection()`
already contains a second pass that lets Steves help with other
incomplete sections, but it was never called again after the initial
assignment.

## Fix
When a Steve's current section is exhausted, `assignSteveToSection()`
is called again to reassign them to another section that still needs
work, and a block is fetched from that new section:

```java
if (block == null) {
    sectionIndex = assignSteveToSection(build, steveName);
    if (sectionIndex != null) {
        section = build.sections.get(sectionIndex);
        block = section.getNextBlock();
    }
}
```

## Impact
Steves now correctly move on to help finish other quadrants once
their own section is done, instead of standing idle while the
collaborative build is still incomplete.

## Testing
- Registered a collaborative build with multiple Steves and an
  uneven block distribution across quadrants; confirmed a Steve
  that finishes its quadrant early is reassigned and continues
  placing blocks in another quadrant instead of stalling.
- Verified `CollaborativeBuild.isComplete()` still correctly reports
  completion once all quadrants are finished.